### PR TITLE
Fix sidebar menu being hidden on most screen sizes

### DIFF
--- a/batadasen/templates/base_sidebar.html
+++ b/batadasen/templates/base_sidebar.html
@@ -4,7 +4,7 @@
 {% load crispy_forms_tags %}
 
 {% block body %}
-    <div id="sidebar" class="col-md-2">
+    <div id="sidebar" class="col-md-3">
         <a class="nav-link" href="/">Start</a>
         <a class="nav-link" href="https://wiki.studentspex.se">Wiki</a>
         <a class="nav-link" href="{% url 'batadasen:person_settings' %}">Inställningar</a>
@@ -16,7 +16,7 @@
         <a class="nav-link" id="admin-link" href="{% url 'admin:index' %}">Admin</a>
         {% endif %}
     </div>
-    <div class="col-md-10">
+    <div class="col-md-9">
         {% block content %} {% endblock %}
     </div>
 {% endblock %}


### PR DESCRIPTION
The sidebar menu option "Inställningar" and the button labeled "Logga ut" was clipped due to the small column width of the menu in most of the screen widths supported by the website. This commit does a quick fix on the subject by increasing the column width of the menu and decreasing the column width of the content. The content should still be given enough space to be usable.

A better fix would be to remove the max-width property entirely from `sm` and `md` bootstrap styles, or make it a percentage of the screen width, but I could not figure out how to go about that in the limited amount I allocated to fixing this issue.