### PR TITLE
Remove the hiding of members with privacy set to PRIVAT from a produc…

### DIFF
--- a/batadasen/views.py
+++ b/batadasen/views.py
@@ -153,10 +153,6 @@ class ProductionDetailView(DetailView):
         for group in context['object'].groups.all():
             memberships = group.memberships.order_by("-title")
 
-            # Exclude persons with private privacy setting for regular users
-            if not self.request.user.has_perm('batadasen.view_private_info'):
-                memberships = memberships.exclude(person__privacy_setting=models.Person.PrivacySetting.PRIVATE)
-
             if not memberships.exists():
                 continue
             result_group = dict()


### PR DESCRIPTION
…tion member listing

Verksamhetens behov av att faktiskt kunna se vem som är med i sin uppsättning måste få gå före individens behov att inte erkänna att de en gång var med i en spexuppsättning.

Efter att ha hört att både directionen och gruppledare haft problem med det här blev det äntligen att jag tog tag i saken och kladda runt i koden lite.