### PR TITLE
Visa medlem utan personuppgifter

### DIFF
--- a/batadasen/models.py
+++ b/batadasen/models.py
@@ -82,9 +82,10 @@ class Person(models.Model):
         max_length=3,
         choices=PrivacySetting.choices,
         default=PrivacySetting.OPEN,
-        help_text='Privat: endast administratörer kan se dina personuppgifter. '
+        help_text='Privat: endast administratörer kan se dina kontaktuppgifter. '
                   'Öppen: andra inloggade kan se all din information. '
-                  'Inga personuppgifter kommer någonsin vara synliga för icke-inloggade.')
+                  'Inga personuppgifter kommer någonsin vara synliga för icke-inloggade. '
+                  'Medlemsnummer och namn kommer alltid vara synligt för inloggade.')
 
     @property
     def full_name(self):

--- a/batadasen/templates/batadasen/person_detail.html
+++ b/batadasen/templates/batadasen/person_detail.html
@@ -21,7 +21,7 @@ Personen har inte betalat medlemsavgift och är för närvarande inte medlem i f
 {% elif object.privacy_setting == 'PVT' %}
 
 <div class="alert alert-danger" role="alert">
-    Personen har valt att dölja sina personuppgifter för andra medlemmar.
+    Personen har valt att dölja sina kontaktuppgifter för andra medlemmar.
 
     {% if perms.batadasen.view_private_info %}
     <br>Du kan bara se dess uppgifter för att du är administratör.

--- a/batadasen/templates/batadasen/person_detail.html
+++ b/batadasen/templates/batadasen/person_detail.html
@@ -21,10 +21,10 @@ Personen har inte betalat medlemsavgift och är för närvarande inte medlem i f
 {% elif object.privacy_setting == 'PVT' %}
 
 <div class="alert alert-danger" role="alert">
-    Personen har valt att dölja all information för andra medlemmar.
+    Personen har valt att dölja sina personuppgifter för andra medlemmar.
 
     {% if perms.batadasen.view_private_info %}
-    <br>Du kan bara se den för att du är administratör.
+    <br>Du kan bara se dess uppgifter för att du är administratör.
     {% endif %}
 </div>
 
@@ -39,6 +39,7 @@ Personen har inte betalat medlemsavgift och är för närvarande inte medlem i f
     <td>Namn</td>
     <td>{{ object.first_name }} {% if object.spex_name %}"{{ object.spex_name }}" {% endif %}{{ object.last_name }}</td>
 </tr>
+{% if object.privacy_setting == 'OPN' or perms.batadasen.view_private_info %}
 <tr>
     <td>E-post</td>
     <td>{% if object.address_list_email %}{{ object.address_list_email }}{% else %}{{ object.email }}{% endif %}</a></td>
@@ -63,6 +64,7 @@ Personen har inte betalat medlemsavgift och är för närvarande inte medlem i f
     <td>Postadress</td>
     <td>{{ object.postal_code }} {{ object.postal_locality }}</a></td>
 </tr>
+{% endif %}
 </table>
 
 <h2>Uppsättningshistorik</h2>

--- a/batadasen/views.py
+++ b/batadasen/views.py
@@ -100,13 +100,6 @@ class EmailListDetailView(DetailView):
 class PersonDetailView(DetailView):
     model = models.Person
 
-    def get_object(self, queryset=None):
-        obj = super(PersonDetailView, self).get_object(queryset)
-        if (obj.privacy_setting == models.Person.PrivacySetting.PRIVATE
-            and not self.request.user.has_perm('batadasen.view_private_info')
-            and not self.request.user == obj.user):
-            raise Http404()
-        return obj
 
 @method_decorator(login_required, name='dispatch')
 class PersonSelfView(UpdateView):


### PR DESCRIPTION
Istället för 404 visas nu en medlem utan dess personuppgifter när man besöker dess URL.